### PR TITLE
feat: modal 버튼 하나만 보일 수 있게 옵션 추가

### DIFF
--- a/src/components/Modal/core.tsx
+++ b/src/components/Modal/core.tsx
@@ -60,10 +60,17 @@ export default function Modal() {
       <S.ModalContent onClick={(e)=>e.stopPropagation()} gap="1.5rem">
         {renderModal()}
         <S.ButtonGroup>
-
-          <Button style={{ background: "#434343" }} variant="contained" size="large" onClick={handleCancel}>
-            {config.cancelText || "취소"}
-          </Button>
+          {/* confirm 타입이고 isOneButton이 true가 아닐 때만 취소 버튼 표시 */}
+          {!(config.type === "confirm" && config.isOneButton) && (
+            <Button 
+              style={{ background: "#434343" }} 
+              variant="contained" 
+              size="large" 
+              onClick={handleCancel}
+            >
+              {config.cancelText || "취소"}
+            </Button>
+          )}
 
           <Button 
             color="primary" 

--- a/src/components/Modal/index.ts
+++ b/src/components/Modal/index.ts
@@ -30,6 +30,7 @@ class ModalService{
                 message:props.message,
                 onConfirm:props.onConfirm,
                 onCancel:props.onCancel,
+                isOneButton:props.isOneButton,
                 confirmText:props.confirmText,
                 cancelText:props.cancelText,
                 type:"confirm"

--- a/src/store/modal/index.ts
+++ b/src/store/modal/index.ts
@@ -8,6 +8,7 @@ interface BaseModalConfig {
 
 export interface ConfirmModalConfig extends BaseModalConfig {
   type: "confirm";
+  isOneButton?: boolean;
   message: string;
   onConfirm: () => void;
 }


### PR DESCRIPTION
# What is this PR?🔎
- 어떤 부분에 대한 개발인지, 피그마에 어디 부분을 개발했는지 기술해주세요.

# Changes📗
- 이제 버튼 하나만 표시 가능합니다.

# Screenshots📸
```typescript
                modal.confirm.show({
                    message:"로그아웃 하시겠습니까?",
                    isOneButton:true,
                    onConfirm:()=>{
                        console.log("로그아웃");
                    }
                });
```
![image](https://github.com/user-attachments/assets/fb74b507-5744-4d59-b244-33c0f0efce88)

# Test Checklist✅
- [X] 테스트 한 부분들을 작성해주세요.
